### PR TITLE
Align with latest CoMeTre changes

### DIFF
--- a/draft-birkholz-cose-cometre-ccf-profile.md
+++ b/draft-birkholz-cose-cometre-ccf-profile.md
@@ -189,7 +189,7 @@ This document requests IANA to add the following new value to the 'COSE Header P
 
 This document requests IANA to add the following new value to the 'Tree Algorithms' registry:
 
-* Identifier: TBD_1
+* Identifier: TBD_1 (requested assignment 2)
 * Tree Algorithm: ccf-ledger
 * Reference: This document
 

--- a/draft-birkholz-cose-cometre-ccf-profile.md
+++ b/draft-birkholz-cose-cometre-ccf-profile.md
@@ -45,41 +45,32 @@ informative:
 
 --- abstract
 
-This document describes a tree algorithm for COSE Signed Merkle Tree Proofs specifically designed for implementations that rely on Trusted Execution Environments (TEEs) to make the
-tree more tamper-resistant.
+This document defines a new verifiable data structure type for COSE Signed Merkle Tree Proofs specifically designed for implementations that rely on Trusted Execution Environments (TEEs) to provide stronger tamper-evidence guarantees.
 
 --- middle
 
 # Introduction
 
-The Concise Encoding of Signed Merkle Tree Proofs (CoMeTre) {{-COMTRE}} defines a standard format for carrying COSE-encoded Merkle Tree proofs and the associated signed root value.
-This is helpful to pove to a verifier that a given serializable element is recorded at a given index in the Merkle Tree, or to prove that a tree is an extension of another.
+The Concise Encoding of Signed Merkle Tree Proofs (CoMeTre) {{-COMTRE}} defines a common framework for defining different types of proofs, such as proof of inclusion, about verifiable data structures (also abbreviated as "logs" in this document). For instance, inclusion proofs guarantee to a verifier that a given serializable element is recorded at a given state of the log, while consistency proofs are used to establish that an inclusion proof is still consistent with the new state of the log at a later time.
 
-In this document, we describe how to verify such CoMeTre proofs for a new type of trees associated with the Confidential Consortium Framework (CCF). Compared to {{-certificate-transparency-v2}}, the leaves of CCF trees carry additional opaque infomation that is used to verify that elements are only written by the Trusted Execution Environment,
-which addresses the persistance of committed transactions that happen between new signatures of
-the Merkle Tree root.
+In this document, we define a new type of log, associated with the Confidential Consortium Framework (CCF) ledger. Compared to {{-certificate-transparency-v2}}, the leaves of CCF trees carry additional opaque information that is used to verify that elements are only written by the Trusted Execution Environment, which addresses the persistence of committed transactions that happen between new signatures of the Merkle Tree root.
 
 ## Requirements Notation
 
 {::boilerplate bcp14-tagged}
 
-# Description of the CCF Tree Algorithm
+# Description of the CCF Ledger Verifiable Data Structure
 
-Recall the definition of CoMeTre inclusion proofs, which are parametrized by 3 CBOR data types that are specific to the Tree Algorithm:
+This documents extends the verifiable data structure registry of {{-COMTRE}} with the following value:
 
-~~~~ cddl
-signed-inclusion-proof = [
-  signed-inclusion-proof: bstr .cbor smtr ; the payload is a merkle root, as described by the tree algorithm, and is detached.
-  inclusion-proof: bstr .cbor CCF-inclusion-proof; the inclusion-proof, as described in the tree algorithm
-  leaf: bstr .cbor CCF-leaf ; the leaf, as described in the tree algorithm
-]
-~~~~
-
-This document defines the `CCF-leaf` and `CCF-inclusion-proof` CBOR types. The signed Merkle Root data type `smtr` is the same as in {{-COMTRE}} but MUST set the protected header parameter carrying the identifier of the tree algorithm, `tree_alg`, to the value TBD_1.
+| Identifier            | Algorithm | Reference
+|---
+|TBD_1 | CCF_LEDGER     | This document
+{: #verifiable-data-structure-values align="left" title="Verifiable Data Structure Algorithms"}
 
 ## Tree Shape
 
-The input of the Merkle Tree Hash (MTH) function is a list of n bytestrings, written D_n = \{d\[0\], d\[1\], ..., d\[n-1\]\}. The output is a single HASH_SIZE bytestring, also called the tree root hash.
+The input of the Merkle Tree Hash (MTH) function is a list of n byte strings, written D_n = \{d\[0\], d\[1\], ..., d\[n-1\]\}. The output is a single HASH_SIZE byte string, also called the Merkle root hash.
 
 This function is defined as follows:
 
@@ -109,7 +100,7 @@ where:
 
 ## Leaf Components
 
-Each leaf in a CCF Merkle Tree carries the following components:
+Each leaf in a CCF ledger carries the following components:
 
 ~~~
 CCF-leaf = [
@@ -119,12 +110,11 @@ CCF-leaf = [
 ]
 ~~~
 
-The `internal_hash` and `internal_data` bytestrings are internal to the CCF implementation. Similarly, the auxiliary tree entries are internal to CCF. They are opaque to receipt Verifiers, but they commit the TS to the whole tree contents and may be used for additional, CCF-specific auditing.
+The `internal_hash` and `internal_data` byte strings are internal to the CCF implementation. Similarly, the auxiliary tree entries are internal to CCF. They are opaque to receipt Verifiers, but they commit the TS to the whole tree contents and may be used for additional, CCF-specific auditing.
 
-## CCF Inclusion Proof Format
+# CCF Inclusion Proofs
 
-CCF inclusion proofs are one of the tree-specific fields of a `signed-inclusion-proof`.
-They consist of a list of digests tagged with a single left-or-right bit.
+CCF inclusion proofs consist of a list of digests tagged with a single left-or-right bit.
 
 ~~~
 CCF-inclusion-proof: [+ proof-element],
@@ -137,9 +127,25 @@ proof-element = [
 
 Unlike some other tree algorithms, the index of the element in the tree is not explicit in the inclusion proof, but the list of left-or-right bits can be treated as the binary decomposition of the index, from the least significant (leaf) to the most significant (root).
 
+## CCF Inclusion Proof Signature
+
+The proof signature for a CCF inclusion proof is a COSE signature (encoded with the `COSE_Sign1` CBOR type) which includes the following additional requirements for protected and unprotected headers. Please note that there may be additional headers defined by the application.
+
+The protected headers for the CCF inclusion proof signature MUST include the following:
+
+* `verifiable-data-structure: int/tstr`. This header MUST be set to the verifiable data structure algorithm identifier for `ccf-ledger` (TBD_1).
+* `proof-type: int`. This header MUST be set to the value of the `inclusion` proof type in the IANA registry of Verifiable Data Structure Proof Type.
+
+The unprotected header for a CCF inclusion proof signature MUST include the following:
+
+* `inclusion-proof: bstr .cbor CCF-inclusion-proof`. This contains the serialized CCF inclusion proof, as defined above.
+* `leaf` (label TBD_2): `bstr .cbor CCF-leaf`. This contains the CCF-specific serialization of the leaf element
+
+The payload of the signature is the CCF ledger Markle root digest, and MUST be detached in order to force verifiers to recompute the root from the inclusion proof in the unprotected header. This provides a safeguard against implementation errors that use the payload of the signature but do not recompute the root from the inclusion proof.
+
 ## Inclusion Proof Verification Algorithm
 
-When a client has received an inclusion proof and wishes to verify inclusion of a signed inclusion proof:
+CCF uses the following algorithm to recompute the payload of the signature based on the `inclusion-proof` header:
 
 ~~~
 compute_root(leaf, proof):
@@ -152,14 +158,12 @@ compute_root(leaf, proof):
            HASH(h + hash) else
   return h
 
-verify_proof(smtr):
-  h = compute_root(smtr.leaf, smtr.inclusion-proof)
-  return verif_cose(smtr.signed-inclusion-proof, h)
+verify_inclusion_proof(signed_proof):
+  leaf := signed_proof.unprotected_headers[LEAF_LABEL] or fail
+  proof := signed_proof.unprotected_headers[INCLUSION_PROOF_LABEL] or fail
+  payload := compute_root(leaf, proof)
+  return verif_cose_detached(signed_proof, payload)
 ~~~
-
-## Signed Consistency Proof
-
-TBD
 
 # Privacy Considerations
 
@@ -173,13 +177,20 @@ Security Considerations
 
 ## Additions to Existing Registries
 
+### COSE Header Parameters registry
+
+This document requests IANA to add the following new value to the 'COSE Header Parameters' registry:
+
+* Label: TBD_2
+* Value type: `bstr`
+* Reference: This document
+
 ### Tree Algorithms {#tree-alg-registry}
 
 This document requests IANA to add the following new value to the 'Tree Algorithms' registry:
 
-
 * Identifier: TBD_1
-* Tree Algorithm: ccf_ledger
+* Tree Algorithm: ccf-ledger
 * Reference: This document
 
 --- back


### PR DESCRIPTION
This uses the new proof type registry and redefines the signature type. Unlike the CT-style log algorithm the proof type is part of the trusted headers